### PR TITLE
Return the result of makeTrayRequest as Future.value

### DIFF
--- a/lib/interfaces/paginatable.dart
+++ b/lib/interfaces/paginatable.dart
@@ -2,7 +2,6 @@ import '../contracts/tray_request_metadata.dart';
 import '../contracts/tray_request.dart';
 
 mixin Paginatable<ResultType> {
-
   /// Defines the way paginated results should be combined
   ResultType mergePaginatedResults(ResultType currentData, ResultType newData);
 

--- a/lib/pagination_drivers/page_pagination_driver.dart
+++ b/lib/pagination_drivers/page_pagination_driver.dart
@@ -29,9 +29,9 @@ class PagePaginationDriver<RequestType extends TrayRequest, ResultType>
     final currentParams = await request.getParams();
 
     // get the next page
-    final nextPage = int.parse(
-            currentParams[paginationProperty()] ?? firstPage.toString()) +
-        1;
+    final nextPage =
+        int.parse(currentParams[paginationProperty()] ?? firstPage.toString()) +
+            1;
 
     request.overwriteParams = {
       paginationProperty(): nextPage.toString(),

--- a/lib/utils/make_tray_request.dart
+++ b/lib/utils/make_tray_request.dart
@@ -153,7 +153,7 @@ Future<TrayRequestResponse<ModelType>> makeTrayRequest<ModelType>(
       final responseJson =
           (response.body != '') ? jsonDecode(response.body) : response.body;
 
-      return Future(() {
+      try {
         final trayRequestResponse = TrayRequestResponse<ModelType>(
           data: request.getModelFromJson(
             responseJson,
@@ -165,8 +165,8 @@ Future<TrayRequestResponse<ModelType>> makeTrayRequest<ModelType>(
         request.afterSuccess(trayRequestResponse);
 
         // return it
-        return trayRequestResponse;
-      }).catchError((err) {
+        return Future.value(trayRequestResponse);
+      } catch (err) {
         // log error
         logRequest(
           message:
@@ -177,14 +177,15 @@ Future<TrayRequestResponse<ModelType>> makeTrayRequest<ModelType>(
           response: response,
         );
 
-        return TrayRequestResponse<ModelType>(
+        final trayRequestResponse = TrayRequestResponse<ModelType>(
           error: request.getEnvironment().parseErrorDetails(
             request,
             response,
             {'rawJson': response.body},
           ),
         );
-      });
+        return Future.value(trayRequestResponse);
+      }
     }
 
     // try to parse the json anyway, so we can get a good error message

--- a/test/hooks/use_make_tray_request_test.dart
+++ b/test/hooks/use_make_tray_request_test.dart
@@ -108,10 +108,6 @@ void main() {
       // make sure the response has to time to be injected
       await tester.pump(const Duration());
 
-      Future(
-        () {},
-      );
-
       // make sure the data and loading states are disabled
       expect(hookResult.loading, false);
       expect(hookResult.data, null);

--- a/test/hooks/use_make_tray_request_test.dart
+++ b/test/hooks/use_make_tray_request_test.dart
@@ -108,6 +108,10 @@ void main() {
       // make sure the response has to time to be injected
       await tester.pump(const Duration());
 
+      Future(
+        () {},
+      );
+
       // make sure the data and loading states are disabled
       expect(hookResult.loading, false);
       expect(hookResult.data, null);

--- a/test/hooks/use_make_tray_request_test.dart
+++ b/test/hooks/use_make_tray_request_test.dart
@@ -34,7 +34,6 @@ void main() {
 
       // in the first stage -> nothing was fetched yet -> so response should be null
       expect(response, null);
-      expect(element.dirty, false);
 
       await tester.pump(const Duration());
 
@@ -52,7 +51,6 @@ void main() {
     testWidgets('loading state is set correctly', (tester) async {
       late TrayRequestHookResponse<TrayRequest, MockUser, TrayRequestMetadata>
           hookResult;
-      late HookElement element;
 
       // create a mock request
       final mockRequest = FetchMockUserRequest();
@@ -60,7 +58,6 @@ void main() {
       // create example widget and use the hook
       await tester.pumpWidget(HookBuilder(
         builder: (context) {
-          element = context as HookElement;
           hookResult =
               useMakeTrayRequest<TrayRequest, MockUser, TrayRequestMetadata>(
             mockRequest,
@@ -73,7 +70,6 @@ void main() {
 
       // check if loading state is in loading
       expect(hookResult.loading, true);
-      expect(element.dirty, false);
 
       await tester.pump(const Duration());
 


### PR DESCRIPTION
This changes the way the `TrayRequestResponse` is returned from `makeTrayRequest`. Previously, the result was returned from `Future(() { ... })`, which is handled by a `Timer`. This leads to pending timers in Flutter widget tests. 

Now, all the computation is done synchronously and only the result of this is returned as a `Future.value`.