### PR TITLE
Handle getModelFromJson errors with a custom exception type 

### DIFF
--- a/lib/src/exceptions/exceptions.dart
+++ b/lib/src/exceptions/exceptions.dart
@@ -1,0 +1,1 @@
+export 'json_conversion_exception.dart';

--- a/lib/src/exceptions/json_conversion_exception.dart
+++ b/lib/src/exceptions/json_conversion_exception.dart
@@ -1,0 +1,11 @@
+class JsonConversionException implements Exception {
+  final String message;
+  final StackTrace? stackTrace;
+
+  JsonConversionException(this.message, [this.stackTrace]);
+
+  @override
+  String toString() {
+    return message;
+  }
+}

--- a/lib/src/fetch_tray_base.dart
+++ b/lib/src/fetch_tray_base.dart
@@ -4,8 +4,10 @@ import 'package:fetch_tray/fetch_tray.dart';
 class FetchTray {
   FetchTray._({
     this.plugins = const [],
+    Dio? dio,
   }) {
-    dio = Dio()
+    final dioClient = dio ?? Dio();
+    this.dio = dioClient
       ..interceptors.addAll([
         ...plugins.map((plugin) => plugin.interceptors).expand(
               (plugin) => plugin,
@@ -15,9 +17,11 @@ class FetchTray {
 
   factory FetchTray.init({
     List<TrayPlugin> plugins = const [],
+    Dio? dio,
   }) {
     _instance = FetchTray._(
       plugins: plugins,
+      dio: dio,
     );
 
     return _instance!;

--- a/lib/src/utils/make_tray_request.dart
+++ b/lib/src/utils/make_tray_request.dart
@@ -3,6 +3,7 @@ import 'package:dio/dio.dart';
 import 'package:logger/logger.dart';
 
 import '../contracts/contracts.dart';
+import '../exceptions/exceptions.dart';
 import '../fetch_tray_base.dart';
 
 const validStatuses = [200, 201];
@@ -122,8 +123,8 @@ Future<TrayRequestResponse<ModelType>> makeTrayRequest<ModelType>(
 
       // return it
       return Future.value(trayRequestResponse);
-    } catch (e) {
-      throw const FormatException();
+    } catch (e, st) {
+      throw JsonConversionException(e.toString(), st);
     }
   } on DioException catch (e) {
     // log error
@@ -162,7 +163,7 @@ Future<TrayRequestResponse<ModelType>> makeTrayRequest<ModelType>(
         ),
       );
     }
-  } on FormatException catch (err) {
+  } on JsonConversionException catch (err) {
     logRequest(
       message:
           'FETCH TRAY EXCEPTION: Could not convert the code to json! ${err.toString()}',
@@ -176,9 +177,10 @@ Future<TrayRequestResponse<ModelType>> makeTrayRequest<ModelType>(
         request,
         response,
         {
-          'message': 'Unexpected server response!',
+          'message': err.message,
         },
         debugInfo: {
+          'stackTrace': err.stackTrace,
           'debugHint':
               'FetchTray result could not be converted! Please check whether the result was really a json entity representing the model. (${err.toString()})',
           'resultBody': response.data,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: fetch_tray
 description: An opinionated, easy to use, and flexible HTTP client for Dart, which can be used with hooks.
-version: 0.3.0-rc.1
+version: 0.3.0-rc.2
 homepage: https://github.com/marqably/fetch_tray
 repository: https://github.com/marqably/fetch_tray
 


### PR DESCRIPTION
This adds a new `JsonConversionException` that is used instead of the previously used `FormatException` in `makeTrayRequest`. This allows us to pass custom props (like the stack trace in this case). 

If a `JsonConversionException` is thrown, it will be converted to a `TrayRequestResponse` (in the `error` property). The resulting `TrayRequestError` has the original `message` and the stack trace from the original exception, which is located inside `error.debugInfo['stackTrace']`.

Additionally, this PR allows developers to pass an optional `Dio` client to the `init` method so that it can be mocked.