### PR TITLE
Add TrayRequestConfig feature

### DIFF
--- a/lib/fetch_tray.dart
+++ b/lib/fetch_tray.dart
@@ -2,4 +2,5 @@ export 'src/contracts/contracts.dart';
 export 'src/interfaces/interfaces.dart';
 export 'src/pagination_drivers/pagination_drivers.dart';
 export 'src/utils/utils.dart';
+export 'src/config/config.dart';
 export 'src/fetch_tray_base.dart';

--- a/lib/src/config/config.dart
+++ b/lib/src/config/config.dart
@@ -1,0 +1,1 @@
+export 'tray_request_config.dart';

--- a/lib/src/config/tray_request_config.dart
+++ b/lib/src/config/tray_request_config.dart
@@ -1,0 +1,9 @@
+typedef TrayRequestConfigMap = Map<Type, TrayRequestConfig>;
+
+class TrayRequestConfig {
+  const TrayRequestConfig({
+    required this.baseUrl,
+  });
+
+  final String baseUrl;
+}

--- a/lib/src/fetch_tray_base.dart
+++ b/lib/src/fetch_tray_base.dart
@@ -1,10 +1,17 @@
 import 'package:dio/dio.dart';
 import 'package:fetch_tray/fetch_tray.dart';
 
+/// The base class for fetch_tray.
+///
+/// It is a singleton class, so you can access it anywhere in your app by calling
+/// `FetchTray.instance`. It is initialized by calling `FetchTray.init()`, which
+/// must be called before using the instance. It can be initialized with a list
+/// of plugins, a Dio instance and a map of request configs.
 class FetchTray {
   FetchTray._({
     this.plugins = const [],
     Dio? dio,
+    this.requestConfigs = const {},
   }) {
     final dioClient = dio ?? Dio();
     this.dio = dioClient
@@ -15,13 +22,17 @@ class FetchTray {
       ]);
   }
 
+  /// Initializes FetchTray with the given [plugins], [dio] instance and
+  /// [requestConfigs].
   factory FetchTray.init({
     List<TrayPlugin> plugins = const [],
     Dio? dio,
+    TrayRequestConfigMap? requestConfigs,
   }) {
     _instance = FetchTray._(
       plugins: plugins,
       dio: dio,
+      requestConfigs: requestConfigs ?? {},
     );
 
     return _instance!;
@@ -36,8 +47,31 @@ class FetchTray {
     return _instance!;
   }
 
+  /// The Dio instance used by FetchTray
   late final Dio dio;
+
+  /// A list of plugins to be used with FetchTray
   late final List<TrayPlugin> plugins;
 
+  /// A map of request configs, where the key is the request type and the value
+  /// is the request config.
+  late final TrayRequestConfigMap requestConfigs;
+
   static FetchTray? _instance;
+
+  /// Returns the request config for the given request type. This is useful
+  /// for example to get the base url for a request. If no request config is
+  /// found for the given request type, an exception is thrown.
+  TrayRequestConfig getRequestConfig(Type request) {
+    assert(
+      requestConfigs.keys.isNotEmpty,
+      'You must provide at least one request config to FetchTray.init to use getRequestConfig',
+    );
+
+    if (requestConfigs.keys.contains(request)) {
+      return requestConfigs[request]!;
+    } else {
+      throw Exception('No request config found for $request');
+    }
+  }
 }


### PR DESCRIPTION
This adds the ability to store request configs when calling `FetchTray.init`. This is useful if we have multiple different types of requests that require different `baseUrl`s within the same FetchTray instance. 

Quick example: 

```dart
// In main.dart
FetchTray.init(
  requestConfigs: {
    MyDefaultRequest: TrayRequestConfig(
      baseUrl: 'https://example.com/api',
    ),
    MyOtherRequest: TrayRequestConfig(
      baseUrl: 'https://something-else.com/api',
    ),
  }
);

// Within a request (or wherever needed): 
FetchTray.instance.getRequestConfig(MyDefaultRequest).baseUrl; // 'https://example.com/api'
```